### PR TITLE
Update composer to bring back laravel 4.1.X compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": ">=4.1.*",
+        "illuminate/support": ">=4.1.0",
         "hautelook/phpass": "0.3.0"
     },
     "autoload": {


### PR DESCRIPTION
Didn't have time to test my fork, but It's a quite simple modification.
